### PR TITLE
Add forgotten docker-compose command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ using the `docker-compose-kafka.yml` file.
 
 To start the Kafka-backed configuration, run:
 
-    $ HOSTNAME=myhostname -f docker-compose.yml -f docker-compose-kafka.yml up
+    $ HOSTNAME=myhostname docker-compose -f docker-compose.yml -f docker-compose-kafka.yml up
 
 ### Legacy
 


### PR DESCRIPTION
Add forgotten docker-compose command in the kafka section of the README
