### PR TITLE
Remove cassandra of docker compose kafka

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,15 @@ To start the MySQL-backed configuration, run:
 
     $ docker-compose -f docker-compose.yml -f docker-compose-mysql.yml up
 
+### Kafka
+
+The docker-compose configuration can be extended to use Kafka instead of Scribe,
+using the `docker-compose-kafka.yml` file. 
+
+To start the Kafka-backed configuration, run:
+
+    $ HOSTNAME=myhostname -f docker-compose.yml -f docker-compose-kafka.yml up
+
 ### Legacy
 
 The Cassandra and MySQL docker-compose files described above use version 2 of

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ using the `docker-compose-kafka.yml` file.
 
 To start the Kafka-backed configuration, run:
 
-    $ HOSTNAME=myhostname -f docker-compose.yml -f docker-compose-kafka.yml up
+    $ HOSTNAME=myhostname docker-compose -f docker-compose.yml -f docker-compose-kafka.yml up
 
 ### Legacy
 

--- a/docker-compose-kafka.yml
+++ b/docker-compose-kafka.yml
@@ -1,0 +1,46 @@
+version: '2'
+services:
+    cassandra:
+        image: cassandra:2.2
+        network_mode: host
+    zookeeper:
+        image: mbabineau/zookeeper-exhibitor:latest
+        network_mode: host
+        environment:
+            HOSTNAME: "${HOSTNAME}"
+    kafka:
+        image: wurstmeister/kafka
+        network_mode: host
+        environment:
+            KAFKA_CREATE_TOPICS: "zipkin:1:1"
+            KAFKA_ZOOKEEPER_CONNECTION_TIMEOUT_MS: 60000
+            KAFKA_ADVERTISED_PORT: 9092
+            KAFKA_ADVERTISED_HOST_NAME: "${HOSTNAME}"
+            KAFKA_ZOOKEEPER_CONNECT: "${HOSTNAME}:2181"
+    collector:
+        image: openzipkin/zipkin-collector:1.35.0
+        network_mode: host
+        environment:
+            STORAGE_TYPE: cassandra
+            TRANSPORT_TYPE: kafka
+            CASSANDRA_CONTACT_POINTS: ${HOSTNAME}
+            KAFKA_ZOOKEEPER: ${HOSTNAME}:2181
+            METADATA_BROKER_LIST: ${HOSTNAME}:9092
+    query:
+        image: openzipkin/zipkin-query:1.35.0
+        network_mode: host
+        environment:
+            STORAGE_TYPE: cassandra
+            TRANSPORT_TYPE: kafka
+            CASSANDRA_CONTACT_POINTS: ${HOSTNAME}
+            KAFKA_ZOOKEEPER: ${HOSTNAME}:2181
+            METADATA_BROKER_LIST: ${HOSTNAME}:9092
+    web:
+        image: openzipkin/zipkin-web:1.35.0
+        network_mode: host
+        environment:
+            TRANSPORT_TYPE: kafka
+            KAFKA_ZOOKEEPER: ${HOSTNAME}:2181
+            METADATA_BROKER_LIST: ${HOSTNAME}:9092
+            QUERY_PORT_9411_TCP_ADDR: ${HOSTNAME}
+            ROOTURL: http://${HOSTNAME}:8080

--- a/docker-compose-kafka.yml
+++ b/docker-compose-kafka.yml
@@ -1,8 +1,5 @@
 version: '2'
 services:
-    cassandra:
-        image: cassandra:2.2
-        network_mode: host
     zookeeper:
         image: mbabineau/zookeeper-exhibitor:latest
         network_mode: host


### PR DESCRIPTION
Cassandra is set by docker-compose when they are executed in the order mentioned in the README

`docker-compose -f docker-compose.yml -f docker-compose-kafka.yml`

so this container fails when it runs because the port is taken by the first cassandra container
